### PR TITLE
fix: uninstall go-bindata before go

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,13 @@
     autoremove: true
   when: ansible_os_family == "Debian"
 
+- name: Golang | Uninstall go-bindata
+  become_user: admin
+  homebrew:
+    name: go-bindata
+    state: absent
+  when: ansible_os_family == "Darwin"
+
 - name: Golang | Uninstall Brew version
   become_user: admin
   homebrew:


### PR DESCRIPTION
To fix issues like :

```
TASK [infra-role-golang : Golang | Uninstall APT version] ********************************************
skipping: [macm2-02.ih-eu-mda1.ci.devel] => {
    "changed": false,
    "false_condition": "ansible_os_family == \"Debian\"",
    "skip_reason": "Conditional result was False"
}

TASK [infra-role-golang : Golang | Uninstall Brew version] *******************************************
fatal: [macm2-02.ih-eu-mda1.ci.devel]: FAILED! => {
    "changed": false
}

MSG:

Error: Refusing to uninstall /opt/homebrew/Cellar/go/1.23.2
because it is required by go-bindata, which is currently installed.
You can override this and force removal with:
  brew uninstall --ignore-dependencies golang

PLAY RECAP *******************************************************************************************
macm2-02.ih-eu-mda1.ci.devel : ok=3    changed=0    unreachable=0    failed=1    skipped=1    rescued=0    
ignored=0
```