### PR TITLE
archive: use gnu tar from nix system packages path on macos

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,7 @@
         dest: '/usr/local'
         remote_src: yes
       environment:
-        PATH: '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin'
+        PATH: '/run/current-system/sw/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin'
 
     - name: Golang | Symlink go binary
       file:


### PR DESCRIPTION
Otherwise:
```bash
Failed to find handler for "/tmp/go1.24.7.darwin-arm64.tar.gz". Make sure the required command to extract the file is installed.
Command "/usr/bin/tar" detected as tar type bsd. GNU tar required.
Command "/usr/bin/unzip" could not handle archive:   End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /tmp/go1.24.7.darwin-arm64.tar.gz or
        /tmp/go1.24.7.darwin-arm64.tar.gz.zip, and cannot find /tmp/go1.24.7.darwin-arm64.tar.gz.ZIP, period.
```

Referenced issue:
* https://github.com/status-im/infra-role-bootstrap-macos/issues/12